### PR TITLE
adding basic tests and total count metric

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,17 +33,15 @@ jobs:
   testing:
     needs: formatting
     runs-on: ubuntu-latest
-    env:
-      RSE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup testing environment
         run: conda create --quiet --name testing pytest
 
-      - name: Test rseng
+      - name: Test caliper
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate testing
           pip install -e .[all]
-          #pytest -sv tests/*.py
+          pytest -sv tests/*.py
           #/bin/bash tests/test_client.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/vsoch/caliper/tree/master) (0.0.x)
+ - adding first metric extractors (0.0.1)
  - skeleton release (0.0.0)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Caliper is a tool for measuring and assessing change in packages.
 
 **under development**
 
-## Core
-
 ### Concepts
 
  - **Manager** a handle to interact with a package manager
@@ -69,6 +67,11 @@ git.add("file.txt")
 git.commit("Adding new content!")
 git.tag("tag")
 ```
+Note that when you run `git.init()` a dummy username and email will be added
+to the `.git/config` file so we can continue interactions without needing a global
+setting. This is done intentionally based on the idea that the user likely won't keep
+the version repository, however if you do want to keep it, feel free to change or
+remote these settings in favor of global ones.
 
 You can imagine how this might be used - we can have a class that can take a manager,
 and then iterate over versions/releases and create a tagged commit for each.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ import tempfile
 git = GitManager(tempfile.mkdtemp())
 git.init()
 
-# copy content to the repository here
+# write some content (file.txt)
 
+git.add("file.txt")
 git.commit("Adding new content!")
 git.tag("tag")
 ```
@@ -184,13 +185,15 @@ And we then might want to see what metrics are available for extraction.
 
 ```python
 extractor.metrics
-{'changedlines': 'caliper.metrics.collection.changedlines.metric.Changedlines'}
+{'totalcounts': 'caliper.metrics.collection.totalcounts.metric.Totalcounts',
+ 'changedlines': 'caliper.metrics.collection.changedlines.metric.Changedlines'}
 ```
 
 Without going into detail, there are different base classes of metrics - a `MetricBase`
 expects to extract some metric for one timepoint (a tag/commit) and a `ChangeMetricBase`
-expects to extract metrics that compare two of these timepoints. The metric above
-we see is a change metric. We can then run the extraction:
+expects to extract metrics that compare two of these timepoints. The metric `changedlines` 
+above is a change metric, and `totalcounts` is a base metric (for one commit timepoint). 
+We can then run the extraction:
 
 ```python
 extractor.extract_metric("changedlines")
@@ -265,6 +268,12 @@ degree of changes for each:
 
 **Note** this is all still being developed, and likely to change!
 
+## TODO
+
+- create official docs in docs folder alongside code
+- write tests to discover and test all metrics (type, name, etc.)
+- think about and implement command line client
+- think of common functions to run metric
 ## License
 
  * Free software: MPL 2.0 License

--- a/caliper/managers/git.py
+++ b/caliper/managers/git.py
@@ -65,7 +65,12 @@ class GitManager:
         dest = dest or self.folder or ""
         self.run_command(["git", "init", dest])
         self._update_repo(dest)
+        self.config("user.name", "vsoch-caliper", dest)
+        self.config("user.email", "vsoch-caliper@users.noreply.github.com", dest)
         return dest
+
+    def config(self, key, value, dest=None):
+        self.run_command(self.init_cmd(dest) + ["config", key, value])
 
     def ls_files(self, dest=None):
         """init an empty repository in a directory of choice"""

--- a/caliper/managers/git.py
+++ b/caliper/managers/git.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import os
+from git import Repo
 from caliper.utils.command import run_command
 from caliper.logger import logger
 
@@ -12,27 +13,23 @@ class GitManager:
     versions (e.g., self.specs) so it does not subclass ManagerBase.
     """
 
-    name = "git"
-
     def __init__(self, folder=None):
         """initialize a git manager. The folder can be empty if intending to
         init a new repository, or not existing if a clone is intended.
         """
         self.folder = folder or ""
+        self._update_repo(self.folder)
 
-    def clone(self, repo, dest=None):
-        """Given a repository, clone it with run_command"""
+    def _update_repo(self, dest):
+        self.repo = Repo()
+        self.git_dir = os.path.join(dest, ".git")
+        if os.path.exists(self.git_dir):
+            self.repo = Repo(self.git_dir)
 
-        # Destination folder can default to present working directory
+    def add(self, filename=".", dest=None):
+        """Add a file to the git repository"""
         dest = dest or self.folder or ""
-        self.run_command(["git", "clone", repo, dest])
-        return dest
-
-    def init(self, dest=None):
-        """init an empty repository in a directory of choice"""
-        dest = dest or self.folder or ""
-        self.run_command(["git", "init", dest])
-        return dest
+        return self.run_command(self.init_cmd(dest) + ["add", filename])
 
     def commit(self, message, dest=None):
         """commit to a particular directory"""
@@ -50,26 +47,49 @@ class GitManager:
             ]
         )
 
-    def add(self, content=None, dest=None):
-        """add files/folders to a git repository"""
+    def status(self, dest=None):
+        """Add a file to the git repository"""
         dest = dest or self.folder or ""
-        content = content or "."
-        return self.run_command(self.init_cmd(dest) + ["add", content])
+        return self.run_command(self.init_cmd(dest) + ["status"])
+
+    def clone(self, repo, dest=None):
+        """Given a repository, clone it with run_command"""
+
+        # Destination folder can default to present working directory
+        dest = dest or self.folder or ""
+        self.run_command(["git", "clone", repo, dest])
+        return dest
+
+    def init(self, dest=None):
+        """init an empty repository in a directory of choice"""
+        dest = dest or self.folder or ""
+        self.run_command(["git", "init", dest])
+        self._update_repo(dest)
+        return dest
+
+    def ls_files(self, dest=None):
+        """init an empty repository in a directory of choice"""
+        dest = dest or self.folder or ""
+        files = self.run_command(self.init_cmd(dest) + ["ls-files"]) or []
+        if files:
+            return [x for x in files[0].split("\n") if x]
+        return files
 
     def tag(self, tag, dest=None):
         """Create a tag for a particular commit"""
         dest = dest or self.folder or ""
         return self.run_command(self.init_cmd(dest) + ["tag", tag])
 
-    def status(self, dest=None):
-        """Get status for a repository"""
-        dest = dest or self.folder or ""
-        return self.run_command(self.init_cmd(dest) + ["status"])
+    @property
+    def tags(self):
+        """A wrapper to expose git.repo.tags"""
+        return getattr(self.repo, "tags", [])
 
     def init_cmd(self, dest):
         """Given a git directory, initialize a command that sets the git-dir
         and working tree
         """
+        dest = dest or "."
         git_dir = os.path.join(dest, ".git")
         return [
             "git",

--- a/caliper/metrics/__init__.py
+++ b/caliper/metrics/__init__.py
@@ -64,8 +64,8 @@ class MetricsExtractor:
             self.prepare_repository()
 
         module, metric_name = self._metrics[name].rsplit(".", 1)
-        metric = getattr(importlib.import_module(module), metric_name)()
-        metric.extract(self.git)
+        metric = getattr(importlib.import_module(module), metric_name)(self.git)
+        metric.extract()
         self._extractors[metric_name] = metric
 
     def prepare_repository(self):

--- a/caliper/metrics/collection/totalcounts/metric.py
+++ b/caliper/metrics/collection/totalcounts/metric.py
@@ -1,0 +1,27 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+from caliper.metrics.base import MetricBase
+
+
+class Totalcounts(MetricBase):
+
+    name = "totalcounts"
+    description = "retrieve total counts of files and lines for each commit"
+
+    def _extract(self, commit):
+        total_files = len(self.git.ls_files())
+        return {
+            "commit": commit.hexsha,
+            "timestamp": commit.authored_datetime.strftime(self.date_time_format),
+            "files": total_files,
+        }
+
+    def get_file_results(self):
+        """return a lookup of changes, where each change has a list of files"""
+        return self._data
+
+    def get_summed_results(self):
+        """Get summed values (e.g., lines changed) across files"""
+        return self._data

--- a/caliper/version.py
+++ b/caliper/version.py
@@ -15,7 +15,10 @@ LICENSE = "LICENSE"
 # Global requirements
 
 
-INSTALL_REQUIRES = (("requests", {"min_version": "2.23.0"}),)
+INSTALL_REQUIRES = (
+    ("requests", {"min_version": "2.23.0"}),
+    ("GitPython", {"min_version": "3.1.7"}),
+)
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
 
 

--- a/caliper/version.py
+++ b/caliper/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.0"
+__version__ = "0.0.1"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "caliper"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [bdist_wheel]
 universal = 1
-
-[tool:pytest]
-collect_ignore = ['setup.py']

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ import os
 
 
 def get_lookup():
-    """get version by way of version file, returns a 
-       lookup dictionary with several global variables without
-       needing to import singularity
+    """get version by way of version file, returns a
+    lookup dictionary with several global variables without
+    needing to import singularity
     """
     lookup = dict()
     version_file = os.path.join("caliper", "version.py")
@@ -24,7 +24,7 @@ def get_lookup():
 
 def get_reqs(lookup=None, key="INSTALL_REQUIRES"):
     """get requirements, mean reading in requirements and versions from
-       the lookup obtained with get_lookup
+    the lookup obtained with get_lookup
     """
     if lookup == None:
         lookup = get_lookup()
@@ -90,7 +90,9 @@ if __name__ == "__main__":
         setup_requires=["pytest-runner"],
         install_requires=INSTALL_REQUIRES,
         tests_require=TESTS_REQUIRES,
-        extras_require={"all": ALL_REQUIRES,},
+        extras_require={
+            "all": ALL_REQUIRES,
+        },
         classifiers=[
             "Intended Audience :: Science/Research",
             "Intended Audience :: Developers",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit test package for rseng."""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,35 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+import os
+import sys
+import pytest
+
+
+def test_git_manager_new(tmp_path):
+    """test git manager"""
+    print("Testing Git Manager")
+    from caliper.managers import GitManager
+
+    git_dir = os.path.join(str(tmp_path), "git-dir")
+
+    # Create empty respository
+    git = GitManager(git_dir)
+    git.init()
+
+    # Add some content
+    content_file = os.path.join(git_dir, "file.txt")
+    with open(content_file, "w") as fd:
+        fd.writelines("pancakes!")
+    git.add("file.txt")
+
+    # Check status, commit, and tag
+    git.status()
+    git.commit("Adding content!")
+    git.tag("content-tag")
+
+    # Now test starting with empty existing repository
+    git = GitManager()
+    git.init(git_dir)
+    git.status(git_dir)

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,0 +1,25 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+import os
+import sys
+import pytest
+
+
+def test_pypi_manager(tmp_path):
+    """test pypi manager"""
+    print("Testing Pypi Manager")
+    from caliper.managers import PypiManager
+
+    manager = PypiManager("sregistry")
+    assert manager.name == "sregistry"
+    assert len(manager.specs) >= 82
+    assert manager.baseurl == "https://pypi.python.org/pypi"
+
+    # Ensure we have correct metadata
+    for key in ["name", "version", "source", "hash"]:
+        assert key in manager.specs[0]
+
+    for key in ["filename", "type"]:
+        assert key in manager.specs[0]["source"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,39 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+import os
+import sys
+import pytest
+
+
+def test_metrics_extractor(tmp_path):
+    """test git manager"""
+    print("Testing Metrics and Extractor")
+    from caliper.managers import PypiManager
+
+    manager = PypiManager("sif")
+
+    from caliper.metrics import MetricsExtractor
+    from caliper.metrics.base import MetricBase, ChangeMetricBase
+
+    extractor = MetricsExtractor(manager)
+
+    # prepare the repository
+    repo = extractor.prepare_repository()
+    extractor.extract_all()
+
+    # test data export for each metric
+    for name, metric in extractor:
+
+        # File results should have lookup by version or
+        file_results = metric.get_file_results()
+        summed_results = metric.get_summed_results()
+
+        # MetricBase has lookup by commit
+        if isinstance(metric, ChangeMetricBase):
+            assert "0.0.1..0.0.11" in file_results
+            assert "0.0.1..0.0.11" in summed_results
+        elif isinstance(metric, MetricBase):
+            assert "0.0.1" in file_results
+            assert "0.0.1" in summed_results


### PR DESCRIPTION
This PR will add basic tests and a simple total count metric (to test the MetricBase). This update also uses the gitpython repo as a paired object with the GitManager so we don't have to think about when to use one vs. the other. Next I'll create a client command to be able to extract metrics (and throw the repository away) on the command line.

Signed-off-by: vsoch <vsochat@stanford.edu>