### PR TITLE
updating export organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/vsoch/caliper/tree/master) (0.0.x)
+ - updating export organization to allow for many json (0.0.16)
  - adding functiondb metric extractor (0.0.15)
  - small bux fixes and addition of docs (0.0.14)
  - adding caliper analyzer (0.0.13)

--- a/caliper/client/__init__.py
+++ b/caliper/client/__init__.py
@@ -6,6 +6,7 @@ __license__ = "MPL 2.0"
 
 import caliper
 from caliper.logger import setup_logger
+from caliper.managers.base import ManagerBase
 import argparse
 import sys
 
@@ -108,9 +109,9 @@ def get_parser():
         "--fmt",
         "--format",
         dest="fmt",
-        help="the format to extract. Defaults to json, but zip is recommended for larger projects.",
-        choices=["json", "zip"],
-        default="json",
+        help="the format to extract. Defaults to json (multiple files).",
+        choices=ManagerBase.export_formats + [None],
+        default=None,
     )
 
     extract.add_argument(

--- a/caliper/managers/base.py
+++ b/caliper/managers/base.py
@@ -10,6 +10,7 @@ class ManagerBase:
     """A manager base exists to define standard actions for a manager."""
 
     name = "base"
+    export_formats = ["json", "zip", "json-single"]
 
     def __init__(self, name=None):
         self.uri = name

--- a/caliper/metrics/__init__.py
+++ b/caliper/metrics/__init__.py
@@ -102,29 +102,30 @@ class MetricsExtractor:
         response = requests.get(url)
         if response.status_code == 200:
             index = response.json()
-            data = index.get('data', {}) 
+            data = index.get("data", {})
 
             # If the extension is json, prefer single file first
             if extension == "json" and "json-single" in data:
-                url = "%s/%s" %(os.path.dirname(url), data['json-single']['url'])
+                url = "%s/%s" % (os.path.dirname(url), data["json-single"]["url"])
                 response = requests.get(url)
                 if response.status_code == 200:
                     return response.json()
 
             elif extension == "zip" and "zip" in data:
                 response = requests.get(url, stream=True)
-                data = zip_from_string(response.content, filename="%s-results.json" % metric)
+                data = zip_from_string(
+                    response.content, filename="%s-results.json" % metric
+                )
                 return json.loads(data)
 
             elif extension == "json" and "json" in data:
                 results = {}
-                for filename in data["json"].get('urls', []):
-                    url = "%s/%s" %(os.path.dirname(url), filename)
+                for filename in data["json"].get("urls", []):
+                    url = "%s/%s" % (os.path.dirname(url), filename)
                     response = requests.get(url)
                     if response.status_code == 200:
                         results.update(response.json())
                 return results
- 
 
     @property
     def metrics(self):

--- a/caliper/metrics/base.py
+++ b/caliper/metrics/base.py
@@ -5,7 +5,7 @@ __license__ = "MPL 2.0"
 from abc import abstractmethod
 from collections.abc import Mapping
 from caliper.logger import logger
-from caliper.utils.file import get_tmpdir
+from caliper.utils.file import mkdir_p, write_json, read_json, get_tmpdir, write_zip
 from distutils.version import StrictVersion
 import os
 
@@ -18,6 +18,9 @@ class MetricBase:
     name = "metric"
     description = "Extract a metric for a particular tag or commit"
     date_time_format = "%Y-%m-%dT%H:%M:%S%z"
+
+    # The extractor is a default, and can be over-ridden by the subclass
+    extractor = "json-single"
 
     def __init__(self, git=None, filename=__file__):
         self._data = {}
@@ -46,16 +49,96 @@ class MetricBase:
         metric, but if given a results dictionary, the metric should be able
         to match a result to a visualization, for example.
         """
-        return {
-            "by-file": self.get_file_results(),
-            "by-group": self.get_group_results(),
-        }
+        pass
 
-    def get_file_results(self):
-        return []
+    def save_json(self, package_dir, force=False):
+        """save an entire folder of json (along with the index)"""
+        results = self.get_results()
+        urls = []
 
-    def get_group_results(self):
-        return []
+        # Get top level keys, labels for each
+        labels = list(results.keys())
+        self._setup_save(package_dir, "json", force)
+        extractor_dir = os.path.join(package_dir, self.name)
+
+        # Organize results by version inside of separate files
+        for label in labels:
+            result_file = os.path.join(extractor_dir, "%s-%s.json" % (self.name, label))
+            newresult = {label: results[label]}
+            urls.append(os.path.basename(result_file))
+            if os.path.exists(result_file) and force is False:
+                logger.warning(
+                    "Result file %s already exists and force is False, skipping overwrite."
+                    % result_file
+                )
+                continue
+            write_json(newresult, result_file)
+
+        # Update the index to include the (relative) list of files
+        self.update_index(extractor_dir, {"json": {"urls": urls}})
+
+    def save_zip(self, package_dir, force=False):
+        """Save a zip file of results (inside the single json file)"""
+        outfile = self._setup_save(package_dir, "zip", force)
+        if not outfile:
+            return
+
+        # Prepare to write results to file
+        jsonfile = "%s-results.json" % self.name
+
+        # Get the results, write to a single updated file
+        results = self.get_results()
+        write_zip({jsonfile: results}, outfile)
+        self.update_index(
+            os.path.dirname(outfile), {"zip": {"url": os.path.basename(outfile)}}
+        )
+
+    def save_json_single(self, package_dir, force=False):
+        """Save a single json file, meaning we generate an index that points to it
+        We return a boolean to indicate if results were written or not.
+        """
+        outfile = self._setup_save(package_dir, "json-single", force)
+        if not outfile:
+            return
+
+        # Get the results, write to a single updated file
+        results = self.get_results()
+        write_json(results, outfile)
+        self.update_index(
+            os.path.dirname(outfile),
+            {"json-single": {"url": os.path.basename(outfile)}},
+        )
+
+    def _setup_save(self, package_dir, fmt, force):
+        """Setup any kind of save, meaning creating necessary output directories
+        and the intended filename.
+        """
+        # Each metric has it's own subfolder
+        extractor_dir = os.path.join(package_dir, self.name)
+        mkdir_p(extractor_dir)
+
+        # Prepare to write results to file
+        if fmt in ["json-single", "zip"]:
+            outfile = os.path.join(extractor_dir, "%s-results.%s" % (self.name, fmt))
+            if os.path.exists(outfile) and not force:
+                logger.warning("%s exists and force is False, skipping." % outfile)
+                return
+            return outfile
+
+    def update_index(self, extractor_dir, content):
+        """If an index already exists, load it and update it with the data type
+        (represented as the key of a dictionary in content). If an index does not
+        exist, write a new one. Filepaths should be relative.
+        """
+        index_file = os.path.join(extractor_dir, "index.json")
+        if not os.path.exists(index_file):
+            index = {"data": {}}
+            write_json(index, index_file)
+
+        # Read in the index and update it
+        index = read_json(index_file)
+        index["data"].update(content)
+        write_json(index, index_file)
 
     def plot_results(self, result_file, outdir=None, force=False, title=None):
         """Given a metric has a template and a function to generate data

--- a/caliper/metrics/base.py
+++ b/caliper/metrics/base.py
@@ -119,6 +119,7 @@ class MetricBase:
 
         # Prepare to write results to file
         if fmt in ["json-single", "zip"]:
+            fmt = "json" if fmt == "json-single" else fmt
             outfile = os.path.join(extractor_dir, "%s-results.%s" % (self.name, fmt))
             if os.path.exists(outfile) and not force:
                 logger.warning("%s exists and force is False, skipping." % outfile)

--- a/caliper/metrics/collection/changedlines/metric.py
+++ b/caliper/metrics/collection/changedlines/metric.py
@@ -54,7 +54,11 @@ class Changedlines(ChangeMetricBase):
         """The second commit should be the parent"""
 
         diffs = {diff.a_path: diff for diff in commit1.diff(commit2)}
+
+        # Results by file (data) and by group
         data = []
+        summary_keys = ["insertions", "deletions", "lines"]
+        group = dict((x, 0) for x in summary_keys)
 
         # commit, we'll iterate through it to get the information we need.
         for filepath, metrics in commit1.stats.files.items():
@@ -79,22 +83,16 @@ class Changedlines(ChangeMetricBase):
                     ),
                 }
             )
+            # Update total counts
+            for key in summary_keys:
+                group[key] += metrics.get(key, 0)
+
             if metrics:
                 data.append(metrics)
 
-        return data
+        # Organize by file and group
+        return {"by-file": data, "by-group": group}
 
-    def get_file_results(self):
+    def get_results(self):
         """return a lookup of changes, where each change has a list of files"""
         return self._data
-
-    def get_group_results(self):
-        """Get summed values (e.g., lines changed) across files"""
-        results = {}
-        summary_keys = ["insertions", "deletions", "lines"]
-        for index, items in self._data.items():
-            results[index] = dict((x, 0) for x in summary_keys)
-            for item in items:
-                for key in summary_keys:
-                    results[index][key] += item.get(key, 0)
-        return results

--- a/caliper/metrics/collection/functiondb/metric.py
+++ b/caliper/metrics/collection/functiondb/metric.py
@@ -16,6 +16,7 @@ class Functiondb(MetricBase):
 
     name = "functiondb"
     description = "for each commit, derive a function database lookup"
+    extractor = "json"
 
     def __init__(self, git):
         super().__init__(git, __file__)
@@ -91,6 +92,6 @@ class Functiondb(MetricBase):
         )
         return lookup
 
-    def get_file_results(self):
+    def get_results(self):
         """we only return file level results, as there are no summed group results"""
         return self._data

--- a/caliper/metrics/collection/totalcounts/metric.py
+++ b/caliper/metrics/collection/totalcounts/metric.py
@@ -21,10 +21,6 @@ class Totalcounts(MetricBase):
             "files": total_files,
         }
 
-    def get_file_results(self):
+    def get_results(self):
         """return a lookup of changes, where each change has a list of files"""
-        return self._data
-
-    def get_group_results(self):
-        """Get summed values (e.g., lines changed) across files"""
         return self._data

--- a/caliper/version.py
+++ b/caliper/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "caliper"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -42,16 +42,10 @@ def test_metrics_extractor(tmp_path):
         # MetricBase has lookup by commit
         if isinstance(metric, ChangeMetricBase):
 
-            # One is required
-            assert results.get("by-group") or results.get("by-file")
-            assert "0.0.1..0.0.11" in results.get("by-group") or ["0.0.1..0.0.11"]
-            assert "0.0.1..0.0.11" in results.get("by-file") or ["0.0.1..0.0.11"]
+            # Top level should be versions
+            assert results.get("0.0.1..0.0.11")
 
         elif isinstance(metric, MetricBase):
 
             # One is required
-            assert results.get("by-group") or results.get("by-file")
-
-            # ensure if no result type is provided, passes
-            assert "0.0.1" in results.get("by-group") or ["0.0.1"]
-            assert "0.0.1" in results.get("by-file") or ["0.0.1"]
+            assert results.get("0.0.1")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,7 +14,7 @@ def test_metrics_loading(tmp_path):
     extractor = MetricsExtractor("pypi:sif")
     result = extractor.load_metric("functiondb")
     assert result
-    assert "by-file" in result
+    assert "0.0.1" in result
 
 
 def test_metrics_extractor(tmp_path):


### PR DESCRIPTION
Since we now have a very large metric which further scales with number of releases, even a compressed (zip) of a json is too big for GitHub (800MB). With this approach, we split the result into versioned filed, and add an index.json to programmatically read them. We still keep support for json-single and zip, which also can be discovered in the index.json.

After merging some example metrics in vsoch/caliper-metrics, I'll update this PR to also be able to read the index / corresponding files. 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>