### PR TITLE
this looks like the correct way to ignore errors with shutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/vsoch/caliper/tree/master) (0.0.x)
- - try catching error on cleanup (0.0.2)
+ - try catching error on cleanup (0.0.2)(0.0.21)
  - fixing bug with cleanup - should only remove if directory exists (0.0.19)
  - adding support to extract functions from filename (0.0.18)
  - adding helper metric function to extract file functions (0.0.17)

--- a/caliper/metrics/extract.py
+++ b/caliper/metrics/extract.py
@@ -177,11 +177,7 @@ class MetricsExtractor:
                 return
 
             # GitHub actions appears to have race condition
-            try:
-                shutil.rmtree(self.tmpdir)
-            except:
-                logger.error("Issue cleaning up %s" % self.tmpdir)
-                pass
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def extract_all(self, versions=None):
         versions = versions or []

--- a/caliper/version.py
+++ b/caliper/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.2"
+__version__ = "0.0.21"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "caliper"


### PR DESCRIPTION
Adding `ignore_errors=True` looks like the correct way to try/except the shutil error.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>